### PR TITLE
Include line breaks in subtitles

### DIFF
--- a/srtparser.h
+++ b/srtparser.h
@@ -234,7 +234,7 @@ inline void SubRipParser::parse(std::string fileName)      //srt parser
             else
             {
                 if (completeLine != "")
-                    completeLine += " ";
+                    completeLine += "\n";
 
                 completeLine += line;
             }


### PR DESCRIPTION
Not sure, if this is wanted in any case - so maybe it would make sense as an option...
But this pull request includes line break information of the subtitle text.