### PR TITLE
mxw: avoid assert

### DIFF
--- a/srtparser.h
+++ b/srtparser.h
@@ -550,7 +550,7 @@ inline void SubtitleItem::extractInfo(bool keepHTML, bool doNotIgnoreNonDialogue
     unique_copy (output.begin(), output.end(), std::back_insert_iterator<std::string>(_justDialogue),
                  [](char a,char b)
                  {
-                     return isspace(a) && isspace(b);
+                     return a>0 && b>0 && isspace(a) && isspace(b);
                  });
 
     // trimming whitespaces


### PR DESCRIPTION
Visual Studio creates an assert here when using the attached file
[Kings.24Lines.zip](https://github.com/saurabhshri/simple-yet-powerful-srt-subtitle-parser-cpp/files/14143862/Kings.24Lines.zip)
